### PR TITLE
Don't set Log user to request.user

### DIFF
--- a/dashboard/apps/hub/admin.py
+++ b/dashboard/apps/hub/admin.py
@@ -165,7 +165,7 @@ class StateAdmin(admin.ModelAdmin):
 
 
     def save_formset(self, request, form, formset, change):
-        if formset.model in (Election, Log):
+        if formset.model == Election:
             instances = formset.save(commit=False)
             for instance in instances:
                 instance.user = request.user


### PR DESCRIPTION
For some reason, when StateAdmin.save_formset is called with the
LogInline form instances, request.user is returned as
SimpleLazyObject instead of ProxyUser.  This behavior is summarized
in this Stack Overflow answer:
http://stackoverflow.com/a/10507200/386210

When this is assigned to the user attribute of the Log instance and
the instance is saved, an error is thrown because the model expects
a ProxyUser object.

ElectionInline is not affected by this.

This works around the error by removing the auto assignment of
the currently logged in user to the user attribute of created
Log instances.  This seems fine as the default form validation
requires the user field to be set when filling out the form
anyway.

Addresses https://github.com/openelections/dashboard/issues/20
